### PR TITLE
[Feature] Players can take amigos on horses

### DIFF
--- a/src/generated/resources/.cache/60b2f0922f180310cd6efe76dad90770bb72d7c9
+++ b/src/generated/resources/.cache/60b2f0922f180310cd6efe76dad90770bb72d7c9
@@ -1,3 +1,4 @@
-// 1.20.1	2025-01-20T22:20:20.8217763	Tags for minecraft:entity_type mod id migamigos
+// 1.20.1	2025-08-08T14:46:07.9263986	Tags for minecraft:entity_type mod id migamigos
 3af55fd03ac813a54d22ce970de7a023e9f7fc5c data/migamigos/tags/entity_types/amigo.json
+0b981afcbd0a2683b0496a6db6f7af8ca9f5cee0 data/migamigos/tags/entity_types/ride_with_player.json
 b5e2c323f72095a6ebe8fd4885ba5d9afcef66dc data/migamigos/tags/entity_types/undead.json

--- a/src/generated/resources/data/migamigos/tags/entity_types/ride_with_player.json
+++ b/src/generated/resources/data/migamigos/tags/entity_types/ride_with_player.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "minecraft:boat",
+    "minecraft:horse"
+  ]
+}

--- a/src/main/java/ttv/migami/migamigos/Config.java
+++ b/src/main/java/ttv/migami/migamigos/Config.java
@@ -27,12 +27,17 @@ public class Config {
     public static class Gameplay
     {
         public final ForgeConfigSpec.BooleanValue friendlyFire;
+        public final ForgeConfigSpec.BooleanValue rideWithPlayer;
 
         public Gameplay(ForgeConfigSpec.Builder builder)
         {
             builder.comment("Properties relating to gameplay").push("gameplay");
             {
                 this.friendlyFire = builder.comment("If enabled, Amigos will receive damage from your attacks.").define("friendlyFire", false);
+                this.rideWithPlayer = builder
+                    .comment("If enabled, Amigos will mount the entity the player is riding when interacting. Rideable entities")
+                    .comment("that support this behavior are configured via the #migamigos:ride_with_player entity_type tag")
+                    .define("rideWithPlayer", true);
             }
             builder.pop();
         }

--- a/src/main/java/ttv/migami/migamigos/client/screen/AmigoScreen.java
+++ b/src/main/java/ttv/migami/migamigos/client/screen/AmigoScreen.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
@@ -88,6 +89,27 @@ public class AmigoScreen extends AbstractContainerScreen<AmigoContainer> {
                             .pos(startX, buttonY)
                             .size(buttonWidth, buttonHeight)
                             .build()
+            );
+        }
+
+        LocalPlayer player = Minecraft.getInstance().player;
+
+        // There's should be probably a better way to add new buttons and actions
+        // Maybe using enums instead of raw ints to encode the action?
+        if (player != null && amigoEntity.canRideWithPlayer(player)) {
+            int buttonY = startY + buttonData.size() * (buttonHeight + buttonSpacing);
+            String format = Component.translatable("gui.migamigos.amigo_inventory.ride_with_player").getString();
+            String translation = player.getVehicle() == null ? format :
+                format.formatted(player.getVehicle().getName().getString());
+
+            this.addRenderableWidget(
+                Button.builder(Component.literal(translation), button -> {
+                    onButtonClick(buttonData.size());
+                    button.setMessage(Component.literal(translation));
+                })
+                .pos(startX, buttonY)
+                .size(buttonWidth, buttonHeight)
+                .build()
             );
         }
     }

--- a/src/main/java/ttv/migami/migamigos/common/network/ServerPlayHandler.java
+++ b/src/main/java/ttv/migami/migamigos/common/network/ServerPlayHandler.java
@@ -132,9 +132,11 @@ public class ServerPlayHandler
                     }
                     break;
                 }
-                // Ride with player
+                // Ride/stop riding with player
                 case 5: {
-                    if (amigoEntity.canRideWithPlayer(player)) {
+                    if (amigoEntity.getVehicle() != null) {
+                        amigoEntity.stopRiding();
+                    } else if (amigoEntity.canRideWithPlayer(player)) {
                         amigoEntity.startRiding(Objects.requireNonNull(player.getVehicle()));
                     }
                 }

--- a/src/main/java/ttv/migami/migamigos/common/network/ServerPlayHandler.java
+++ b/src/main/java/ttv/migami/migamigos/common/network/ServerPlayHandler.java
@@ -19,6 +19,7 @@ import net.minecraft.world.entity.player.Player;
 import ttv.migami.migamigos.entity.AmigoEntity;
 import ttv.migami.migamigos.init.ModSounds;
 
+import java.util.Objects;
 import java.util.UUID;
 
 import static ttv.migami.migamigos.common.AmigoDataHandler.getAmigoByUUID;
@@ -130,6 +131,12 @@ public class ServerPlayHandler
                         amigoEntity.setPostPos(amigoEntity.getOnPos().getCenter().toVector3f());
                     }
                     break;
+                }
+                // Ride with player
+                case 5: {
+                    if (amigoEntity.canRideWithPlayer(player)) {
+                        amigoEntity.startRiding(Objects.requireNonNull(player.getVehicle()));
+                    }
                 }
             }
         }

--- a/src/main/java/ttv/migami/migamigos/datagen/EntityTagGen.java
+++ b/src/main/java/ttv/migami/migamigos/datagen/EntityTagGen.java
@@ -26,6 +26,10 @@ public class EntityTagGen extends EntityTypeTagsProvider
                 .add(ModEntities.COCOGOAT.get())
                 .add(ModEntities.WAVELYN.get());
 
+        this.tag(ModTags.Entities.RIDE_WITH_PLAYER)
+            .add(EntityType.BOAT)
+            .add(EntityType.HORSE);
+
         this.tag(ModTags.Entities.UNDEAD)
                 .add(EntityType.ZOMBIE)
                 .add(EntityType.DROWNED)

--- a/src/main/java/ttv/migami/migamigos/entity/AmigoEntity.java
+++ b/src/main/java/ttv/migami/migamigos/entity/AmigoEntity.java
@@ -45,11 +45,13 @@ import software.bernie.geckolib.core.animatable.instance.AnimatableInstanceCache
 import software.bernie.geckolib.core.animation.AnimatableManager;
 import software.bernie.geckolib.util.GeckoLibUtil;
 import ttv.migami.migamigos.AmigoAnimations;
+import ttv.migami.migamigos.Config;
 import ttv.migami.migamigos.common.Amigo;
 import ttv.migami.migamigos.common.amigo.Action;
 import ttv.migami.migamigos.common.container.AmigoContainer;
 import ttv.migami.migamigos.entity.ai.*;
 import ttv.migami.migamigos.init.ModSounds;
+import ttv.migami.migamigos.init.ModTags;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -142,7 +144,6 @@ public class AmigoEntity extends PathfinderMob implements GeoEntity {
      *  The position of this Amigo's Post (where the Amigo will go back after being set not to follow).
      */
     private static final EntityDataAccessor<Vector3f> DATA_POST_POS = SynchedEntityData.defineId(AmigoEntity.class, EntityDataSerializers.VECTOR3);
-
 
     private final SimpleContainer inventory = new SimpleContainer(14);
 
@@ -786,6 +787,25 @@ public class AmigoEntity extends PathfinderMob implements GeoEntity {
 
     public boolean wantsToAttack(LivingEntity pTarget, LivingEntity pOwner) {
         return true;
+    }
+
+    public boolean canRideWithPlayer(Player player) {
+        Entity vehicle = player.getVehicle();
+
+        if (vehicle == null || this.getVehicle() != null) {
+            return false;
+        }
+
+        if (!Config.COMMON.gameplay.rideWithPlayer.get()) {
+            return false;
+        }
+
+        if (vehicle.getPassengers().size() > 1) {
+            return false;
+        }
+
+        // Allow players to add this behaviour to other entity vehicles instead of only horses
+        return vehicle.getType().is(ModTags.Entities.RIDE_WITH_PLAYER);
     }
 
     public int getTolerance() {

--- a/src/main/java/ttv/migami/migamigos/event/CommonEntityEvents.java
+++ b/src/main/java/ttv/migami/migamigos/event/CommonEntityEvents.java
@@ -18,11 +18,11 @@ public class CommonEntityEvents {
         if (event.getEntityMounting() instanceof ServerPlayer) {
             Entity vehicle = event.getEntityBeingMounted();
 
-            if (vehicle != null) {
-                for (Entity entity : vehicle.getPassengers()) {
-                    if (entity instanceof AmigoEntity amigo) {
-                        amigo.stopRiding();
-                    }
+            if (vehicle == null) return;
+
+            for (Entity entity : vehicle.getPassengers()) {
+                if (entity instanceof AmigoEntity amigo && amigo.isFollowing()) {
+                    amigo.stopRiding();
                 }
             }
         }

--- a/src/main/java/ttv/migami/migamigos/event/CommonEntityEvents.java
+++ b/src/main/java/ttv/migami/migamigos/event/CommonEntityEvents.java
@@ -1,0 +1,30 @@
+package ttv.migami.migamigos.event;
+
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraftforge.event.entity.EntityMountEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import ttv.migami.migamigos.entity.AmigoEntity;
+
+@Mod.EventBusSubscriber
+public class CommonEntityEvents {
+    @SubscribeEvent
+    public static void onEntityMount(EntityMountEvent event) {
+        if (event.isMounting()) {
+            return;
+        }
+
+        if (event.getEntityMounting() instanceof ServerPlayer) {
+            Entity vehicle = event.getEntityBeingMounted();
+
+            if (vehicle != null) {
+                for (Entity entity : vehicle.getPassengers()) {
+                    if (entity instanceof AmigoEntity amigo) {
+                        amigo.stopRiding();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/ttv/migami/migamigos/init/ModTags.java
+++ b/src/main/java/ttv/migami/migamigos/init/ModTags.java
@@ -13,6 +13,7 @@ public class ModTags
     {
         public static final TagKey<EntityType<?>> AMIGO = tag("amigo");
         public static final TagKey<EntityType<?>> UNDEAD = tag("undead");
+        public static final TagKey<EntityType<?>> RIDE_WITH_PLAYER = tag("ride_with_player");
 
         public static TagKey<EntityType<?>> tag(String name)
         {

--- a/src/main/java/ttv/migami/migamigos/mixin/MixinAbstractHorse.java
+++ b/src/main/java/ttv/migami/migamigos/mixin/MixinAbstractHorse.java
@@ -1,0 +1,52 @@
+package ttv.migami.migamigos.mixin;
+
+import net.minecraft.util.Mth;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.animal.Animal;
+import net.minecraft.world.entity.animal.horse.AbstractHorse;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+@Mixin(AbstractHorse.class)
+public abstract class MixinAbstractHorse extends Animal {
+
+    @Shadow private float standAnimO;
+
+    protected MixinAbstractHorse(EntityType<? extends Animal> pEntityType, Level pLevel) {
+        super(pEntityType, pLevel);
+    }
+
+    @Inject(at = @At("HEAD"), method = "positionRider", cancellable = true)
+    private void migamigos$positionRider(Entity pPassenger, MoveFunction pCallback, CallbackInfo ci) {
+        List<Entity> passengers = getPassengers();
+        boolean isControlling = Math.max(passengers.indexOf(pPassenger), 0) == 0;
+
+        double offsetX = 0.0F;
+        double offsetY = 0.0F;
+
+        double v1 = Mth.sin(this.yBodyRot * ((float) Math.PI / 180F));
+        double v2 = Mth.cos(this.yBodyRot * ((float) Math.PI / 180F));
+        double v3 = 0.6f * standAnimO;
+        double v4 = 0.175f * standAnimO;
+
+        if (passengers.size() > 1) {
+            // This values may be tweaked later for better positioning
+            offsetX = isControlling ? 0.14 : -0.5 + 0.3 * standAnimO;
+            offsetY = isControlling ? 0.0 : -0.2 * standAnimO;
+        }
+
+        Vec3 rotation = (new Vec3(0.0F, 0.0F, offsetX)).yRot(-this.yBodyRot * (float)Math.PI / 180.0F);
+        double pHeight = this.getY() + this.getPassengersRidingOffset() + pPassenger.getMyRidingOffset();
+
+        pCallback.accept(pPassenger, this.getX() + (v3 * v1) + rotation.x, pHeight + v4 + offsetY, this.getZ() - (v3 * v2) + rotation.z);
+        ci.cancel();
+    }
+}

--- a/src/main/java/ttv/migami/migamigos/mixin/MixinEntity.java
+++ b/src/main/java/ttv/migami/migamigos/mixin/MixinEntity.java
@@ -1,0 +1,41 @@
+package ttv.migami.migamigos.mixin;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.animal.horse.AbstractHorse;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import ttv.migami.migamigos.Config;
+import ttv.migami.migamigos.entity.AmigoEntity;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+@Mixin(Entity.class)
+public abstract class MixinEntity {
+    @Shadow public abstract List<Entity> getPassengers();
+
+    @Shadow public abstract EntityType<?> getType();
+
+    @Shadow @Nullable public abstract LivingEntity getControllingPassenger();
+
+    @Inject(at = @At("HEAD"), method = "canAddPassenger", cancellable = true)
+    private void migamigos$allowAmigoOnHorse(Entity pPassenger, CallbackInfoReturnable<Boolean> cir) {
+        if (!Config.COMMON.gameplay.rideWithPlayer.get())
+            return;
+
+        if (((Object) this) instanceof AbstractHorse) {
+            if (getPassengers().size() > 1)
+                return;
+
+            if (getControllingPassenger() instanceof Player && pPassenger instanceof AmigoEntity) {
+                cir.setReturnValue(true);
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/migamigos/lang/en_us.json
+++ b/src/main/resources/assets/migamigos/lang/en_us.json
@@ -26,6 +26,7 @@
   "gui.migamigos.amigo_inventory.allow_wandering.false": "Cannot Wander",
   "gui.migamigos.amigo_inventory.following.true": "Is Following",
   "gui.migamigos.amigo_inventory.following.false": "Is Staying",
+  "gui.migamigos.amigo_inventory.ride_with_player": "Get on %s",
   "cutesy.migamigos.thanks": "Thank you for using Migamigos!",
   "chat.migamigos.favorite_item": "They like %1$s!",
   "chat.migamigos.foe_appeared": "A new foe has appeared!",

--- a/src/main/resources/assets/migamigos/lang/en_us.json
+++ b/src/main/resources/assets/migamigos/lang/en_us.json
@@ -27,6 +27,7 @@
   "gui.migamigos.amigo_inventory.following.true": "Is Following",
   "gui.migamigos.amigo_inventory.following.false": "Is Staying",
   "gui.migamigos.amigo_inventory.ride_with_player": "Get on %s",
+  "gui.migamigos.amigo_inventory.stop_riding": "Get off %s",
   "cutesy.migamigos.thanks": "Thank you for using Migamigos!",
   "chat.migamigos.favorite_item": "They like %1$s!",
   "chat.migamigos.foe_appeared": "A new foe has appeared!",

--- a/src/main/resources/migamigos.mixins.json
+++ b/src/main/resources/migamigos.mixins.json
@@ -1,15 +1,17 @@
 {
-  "required": true,
-  "package": "ttv.migami.migamigos.mixin",
-  "compatibilityLevel": "JAVA_8",
-  "minVersion": "0.8",
-  "refmap": "migamigos.refmap.json",
-  "plugin": "ttv.migami.migamigos.mixin.MixinPlugin",
-  "mixins": [
-  ],
-  "client": [
-  ],
-  "injectors": {
-    "defaultRequire": 1
+    "required": true,
+    "package": "ttv.migami.migamigos.mixin",
+    "compatibilityLevel": "JAVA_8",
+    "minVersion": "0.8",
+    "refmap": "migamigos.refmap.json",
+    "plugin": "ttv.migami.migamigos.mixin.MixinPlugin",
+    "mixins": [
+        "MixinAbstractHorse",
+        "MixinEntity"
+    ],
+    "client": [
+    ],
+    "injectors": {
+        "defaultRequire": 1
   }
 }


### PR DESCRIPTION
Now amigos will be able ride supported entities with the player:

- When the player is riding an entity that has the entity_type tag `#migamigos:ride_with_player` (e.g., a horse), a new option will appear in the side buttons on the *amigo* gui. When clicked, the amigo will start riding the entity so the player can take them.
- If the *amigo* is `following` the player, they will automatically dismount the entity with the player, otherwise, they will stay on the entity.
- To dismount an amigo from an entity, just right click them and click the  `Get off <entity>` button on the gui.

Also, something to note:

1. This feature can be turned off with the setting `rideWithPlayer` in the config;
2. Players can add this feature to any rideable entity by using the `#migamigos:ride_with_player` tag, but they should be aware that adding an entity that doesn't support more than one passenger may have unexpected results.